### PR TITLE
Explicitly reference std::result::Result within macros

### DIFF
--- a/src/macro_validated_customized_hash_set.rs
+++ b/src/macro_validated_customized_hash_set.rs
@@ -61,13 +61,13 @@ impl<'de, V: ValidatedHashSetWrapper<T>, T: ValidatedWrapper + Eq + Hash + serde
 macro_rules! validated_customized_hash_set_struct_implement_se_de {
      ( $name:ident ) => {
         impl<'de, T: ::validators::ValidatedWrapper + Eq + ::std::hash::Hash + ::validators::serde::Deserialize<'de>> ::validators::serde::Deserialize<'de> for $name<T> {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
                 deserializer.deserialize_seq(::validators::HashSetVisitor(Vec::<$name<T>>::new(), Vec::<T>::new()))
             }
         }
 
         impl<T: ::validators::ValidatedWrapper + Eq + ::std::hash::Hash + ::validators::serde::Serialize> ::validators::serde::Serialize for $name<T> {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
                 serializer.collect_seq(self.as_hash_set().iter())
             }
         }
@@ -91,7 +91,7 @@ macro_rules! validated_customized_hash_set_struct_implement_from_form_value {
         impl<'a, T: ::validators::ValidatedWrapper + Eq + ::std::hash::Hash> ::validators::rocket::request::FromFormValue<'a> for $name<T> {
             type Error = ::validators::ValidatedCustomizedHashSetError;
 
-            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error>{
+            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error>{
                 $name::from_string(form_value.url_decode().map_err(|err| ::validators::ValidatedCustomizedHashSetError::UTF8Error(err))?)
             }
         }
@@ -99,7 +99,7 @@ macro_rules! validated_customized_hash_set_struct_implement_from_form_value {
         impl<'a, T: ::validators::ValidatedWrapper + Eq + ::std::hash::Hash> ::validators::rocket::request::FromParam<'a> for $name<T> {
             type Error = ::validators::ValidatedCustomizedHashSetError;
 
-            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error> {
+            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error> {
                 $name::from_string(param.url_decode().map_err(|err| ::validators::ValidatedCustomizedHashSetError::UTF8Error(err))?)
             }
         }
@@ -186,17 +186,17 @@ macro_rules! validated_customized_hash_set_struct {
         impl<T: ::validators::ValidatedWrapper + Eq + ::std::hash::Hash> ::validators::ValidatedWrapper for $name<T> {
             type Error = ::validators::ValidatedCustomizedHashSetError;
 
-            fn from_string($from_string_input: String) -> Result<Self, Self::Error>{
+            fn from_string($from_string_input: String) -> std::result::Result<Self, Self::Error>{
                 $name::from_string($from_string_input)
             }
 
-            fn from_str($from_str_input: &str) -> Result<Self, Self::Error>{
+            fn from_str($from_str_input: &str) -> std::result::Result<Self, Self::Error>{
                 $name::from_str($from_str_input)
             }
         }
 
         impl<T: ::validators::ValidatedWrapper + Eq + ::std::hash::Hash> ::validators::ValidatedHashSetWrapper<T> for $name<T> {
-            fn from_hash_set($from_hash_set_input: ::std::collections::HashSet<T>) -> Result<Self, ::validators::ValidatedCustomizedHashSetError>{
+            fn from_hash_set($from_hash_set_input: ::std::collections::HashSet<T>) -> std::result::Result<Self, ::validators::ValidatedCustomizedHashSetError>{
                 $name::from_hash_set($from_hash_set_input)
             }
         }
@@ -210,7 +210,7 @@ macro_rules! validated_customized_hash_set_struct {
                 self.$field
             }
 
-            pub fn from_string($from_string_input: String) -> Result<Self, ::validators::ValidatedCustomizedHashSetError>{
+            pub fn from_string($from_string_input: String) -> std::result::Result<Self, ::validators::ValidatedCustomizedHashSetError>{
                 let $field = match $from_string {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -219,7 +219,7 @@ macro_rules! validated_customized_hash_set_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_str($from_str_input: &str) -> Result<Self, ::validators::ValidatedCustomizedHashSetError>{
+            pub fn from_str($from_str_input: &str) -> std::result::Result<Self, ::validators::ValidatedCustomizedHashSetError>{
                 let $field = match $from_str {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -228,7 +228,7 @@ macro_rules! validated_customized_hash_set_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_hash_set($from_hash_set_input: ::std::collections::HashSet<T>) -> Result<Self, ::validators::ValidatedCustomizedHashSetError>{
+            pub fn from_hash_set($from_hash_set_input: ::std::collections::HashSet<T>) -> std::result::Result<Self, ::validators::ValidatedCustomizedHashSetError>{
                 let $field = match $from_hash_set {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)

--- a/src/macro_validated_customized_number.rs
+++ b/src/macro_validated_customized_number.rs
@@ -138,7 +138,7 @@ impl<'de, V, T> serde::de::Visitor<'de> for NumberVisitor<V, T> where V: Validat
 macro_rules! validated_customized_number_struct_implement_se_de {
     ( $name:ident, $t:ident ) => {
         impl<'de> ::validators::serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
                 let v = ::validators::NumberVisitor(Vec::<$name>::new(), Vec::<$t>::new());
 
                 match stringify!($t) {
@@ -160,7 +160,7 @@ macro_rules! validated_customized_number_struct_implement_se_de {
         }
 
         impl ::validators::serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
                 match stringify!($t) {
                     "u8" => serializer.serialize_u8(self.get_number() as u8),
                     "u16" => serializer.serialize_u16(self.get_number() as u16),
@@ -198,7 +198,7 @@ macro_rules! validated_customized_number_struct_implement_from_form_value {
         impl<'a> ::validators::rocket::request::FromFormValue<'a> for $name {
             type Error = ::validators::ValidatedCustomizedNumberError;
 
-            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error>{
+            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error>{
                 $name::from_string(form_value.url_decode().map_err(|err| ::validators::ValidatedCustomizedNumberError::UTF8Error(err))?)
             }
         }
@@ -206,7 +206,7 @@ macro_rules! validated_customized_number_struct_implement_from_form_value {
         impl<'a> ::validators::rocket::request::FromParam<'a> for $name {
             type Error = ::validators::ValidatedCustomizedNumberError;
 
-            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error> {
+            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error> {
                 $name::from_string(param.url_decode().map_err(|err| ::validators::ValidatedCustomizedNumberError::UTF8Error(err))?)
             }
         }
@@ -300,17 +300,17 @@ macro_rules! validated_customized_number_struct {
         impl ::validators::ValidatedWrapper for $name {
             type Error = ::validators::ValidatedCustomizedNumberError;
 
-            fn from_string($from_string_input: String) -> Result<Self, Self::Error>{
+            fn from_string($from_string_input: String) -> std::result::Result<Self, Self::Error>{
                 $name::from_string($from_string_input)
             }
 
-            fn from_str($from_str_input: &str) -> Result<Self, Self::Error>{
+            fn from_str($from_str_input: &str) -> std::result::Result<Self, Self::Error>{
                 $name::from_str($from_str_input)
             }
         }
 
         impl<T: ::validators::number_as::Number> ::validators::ValidatedNumberWrapper<T> for $name {
-            fn from_number($from_number_input: T) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            fn from_number($from_number_input: T) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 $name::from_number($from_number_input.number_as())
             }
         }
@@ -336,7 +336,7 @@ macro_rules! validated_customized_number_struct {
                 self.$field as u128 as $t == self.$field
             }
 
-            pub fn from_string($from_string_input: String) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_string($from_string_input: String) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let $field = match $from_string {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -345,7 +345,7 @@ macro_rules! validated_customized_number_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_str($from_str_input: &str) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_str($from_str_input: &str) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let $field = match $from_str {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -354,7 +354,7 @@ macro_rules! validated_customized_number_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_number($from_number_input: $t) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_number($from_number_input: $t) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let $field = match $from_number {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -363,7 +363,7 @@ macro_rules! validated_customized_number_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_f64($from_number_input: f64) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_f64($from_number_input: f64) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as f64 != $from_number_input {
@@ -373,7 +373,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_f32($from_number_input: f32) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_f32($from_number_input: f32) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as f32 != $from_number_input {
@@ -383,7 +383,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_i8($from_number_input: i8) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_i8($from_number_input: i8) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as i8 != $from_number_input {
@@ -393,7 +393,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_i16($from_number_input: i16) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_i16($from_number_input: i16) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as i16 != $from_number_input {
@@ -403,7 +403,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_i32($from_number_input: i32) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_i32($from_number_input: i32) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as i32 != $from_number_input {
@@ -413,7 +413,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_i64($from_number_input: i64) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_i64($from_number_input: i64) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as i64 != $from_number_input {
@@ -423,7 +423,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_i128($from_number_input: i128) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_i128($from_number_input: i128) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as i128 != $from_number_input {
@@ -433,7 +433,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_u8($from_number_input: u8) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_u8($from_number_input: u8) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as u8 != $from_number_input {
@@ -443,7 +443,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_u16($from_number_input: u16) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_u16($from_number_input: u16) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as u16 != $from_number_input {
@@ -453,7 +453,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_u32($from_number_input: u32) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_u32($from_number_input: u32) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as u32 != $from_number_input {
@@ -463,7 +463,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_u64($from_number_input: u64) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_u64($from_number_input: u64) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as u64 != $from_number_input {
@@ -473,7 +473,7 @@ macro_rules! validated_customized_number_struct {
                 Self::from_number(v)
             }
 
-            pub fn from_u128($from_number_input: u128) -> Result<Self, ::validators::ValidatedCustomizedNumberError>{
+            pub fn from_u128($from_number_input: u128) -> std::result::Result<Self, ::validators::ValidatedCustomizedNumberError>{
                 let v = $from_number_input as $t;
 
                 if v as u128 != $from_number_input {

--- a/src/macro_validated_customized_string.rs
+++ b/src/macro_validated_customized_string.rs
@@ -50,13 +50,13 @@ impl<'de, V: ValidatedWrapper> serde::de::Visitor<'de> for StringVisitor<V> {
 macro_rules! validated_customized_string_struct_implement_se_de {
      ( $name:ident ) => {
         impl<'de> ::validators::serde::Deserialize<'de> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
                 deserializer.deserialize_string(::validators::StringVisitor(Vec::<$name>::new()))
             }
         }
 
         impl ::validators::serde::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
                 serializer.serialize_str(self.as_str())
             }
         }
@@ -80,7 +80,7 @@ macro_rules! validated_customized_string_struct_implement_from_form_value {
         impl<'a> ::validators::rocket::request::FromFormValue<'a> for $name {
             type Error = ::validators::ValidatedCustomizedStringError;
 
-            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error>{
+            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error>{
                 $name::from_string(form_value.url_decode().map_err(|err| ::validators::ValidatedCustomizedStringError::UTF8Error(err))?)
             }
         }
@@ -88,7 +88,7 @@ macro_rules! validated_customized_string_struct_implement_from_form_value {
         impl<'a> ::validators::rocket::request::FromParam<'a> for $name {
             type Error = ::validators::ValidatedCustomizedStringError;
 
-            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error> {
+            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error> {
                 $name::from_string(param.url_decode().map_err(|err| ::validators::ValidatedCustomizedStringError::UTF8Error(err))?)
             }
         }
@@ -134,11 +134,11 @@ macro_rules! validated_customized_string_struct {
         impl ::validators::ValidatedWrapper for $name {
             type Error = ::validators::ValidatedCustomizedStringError;
 
-            fn from_string($from_string_input: String) -> Result<Self, Self::Error>{
+            fn from_string($from_string_input: String) -> std::result::Result<Self, Self::Error>{
                 $name::from_string($from_string_input)
             }
 
-            fn from_str($from_str_input: &str) -> Result<Self, Self::Error>{
+            fn from_str($from_str_input: &str) -> std::result::Result<Self, Self::Error>{
                 $name::from_str($from_str_input)
             }
         }
@@ -152,7 +152,7 @@ macro_rules! validated_customized_string_struct {
                 self.$field
             }
 
-            pub fn from_string($from_string_input: String) -> Result<Self, ::validators::ValidatedCustomizedStringError>{
+            pub fn from_string($from_string_input: String) -> std::result::Result<Self, ::validators::ValidatedCustomizedStringError>{
                 let $field = match $from_string {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -161,7 +161,7 @@ macro_rules! validated_customized_string_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_str($from_str_input: &str) -> Result<Self, ::validators::ValidatedCustomizedStringError>{
+            pub fn from_str($from_str_input: &str) -> std::result::Result<Self, ::validators::ValidatedCustomizedStringError>{
                 let $field = match $from_str {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)

--- a/src/macro_validated_customized_vec.rs
+++ b/src/macro_validated_customized_vec.rs
@@ -59,13 +59,13 @@ impl<'de, V: ValidatedVecWrapper<T>, T: ValidatedWrapper + serde::Deserialize<'d
 macro_rules! validated_customized_vec_struct_implement_se_de {
      ( $name:ident ) => {
         impl<'de, T: ::validators::ValidatedWrapper + ::validators::serde::Deserialize<'de>> ::validators::serde::Deserialize<'de> for $name<T> {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error> where D: ::validators::serde::Deserializer<'de> {
                 deserializer.deserialize_seq(::validators::VecVisitor(Vec::<$name<T>>::new(), Vec::<T>::new()))
             }
         }
 
         impl<T: ::validators::ValidatedWrapper + ::validators::serde::Serialize> ::validators::serde::Serialize for $name<T> {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> where S: ::validators::serde::Serializer {
                 serializer.collect_seq(self.as_vec().iter())
             }
         }
@@ -89,7 +89,7 @@ macro_rules! validated_customized_vec_struct_implement_from_form_value {
         impl<'a, T: ::validators::ValidatedWrapper> ::validators::rocket::request::FromFormValue<'a> for $name<T> {
             type Error = ::validators::ValidatedCustomizedVecError;
 
-            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error>{
+            fn from_form_value(form_value: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error>{
                 $name::from_string(form_value.url_decode().map_err(|err| ::validators::ValidatedCustomizedVecError::UTF8Error(err))?)
             }
         }
@@ -97,7 +97,7 @@ macro_rules! validated_customized_vec_struct_implement_from_form_value {
         impl<'a, T: ::validators::ValidatedWrapper> ::validators::rocket::request::FromParam<'a> for $name<T> {
             type Error = ::validators::ValidatedCustomizedVecError;
 
-            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> Result<Self, Self::Error> {
+            fn from_param(param: &'a ::validators::rocket::http::RawStr) -> std::result::Result<Self, Self::Error> {
                 $name::from_string(param.url_decode().map_err(|err| ::validators::ValidatedCustomizedVecError::UTF8Error(err))?)
             }
         }
@@ -178,17 +178,17 @@ macro_rules! validated_customized_vec_struct {
         impl<T: ::validators::ValidatedWrapper> ::validators::ValidatedWrapper for $name<T> {
             type Error = ::validators::ValidatedCustomizedVecError;
 
-            fn from_string($from_string_input: String) -> Result<Self, Self::Error>{
+            fn from_string($from_string_input: String) -> std::result::Result<Self, Self::Error>{
                 $name::from_string($from_string_input)
             }
 
-            fn from_str($from_str_input: &str) -> Result<Self, Self::Error>{
+            fn from_str($from_str_input: &str) -> std::result::Result<Self, Self::Error>{
                 $name::from_str($from_str_input)
             }
         }
 
         impl<T: ::validators::ValidatedWrapper> ::validators::ValidatedVecWrapper<T> for $name<T> {
-            fn from_vec($from_vec_input: Vec<T>) -> Result<Self, ::validators::ValidatedCustomizedVecError>{
+            fn from_vec($from_vec_input: Vec<T>) -> std::result::Result<Self, ::validators::ValidatedCustomizedVecError>{
                 $name::from_vec($from_vec_input)
             }
         }
@@ -202,7 +202,7 @@ macro_rules! validated_customized_vec_struct {
                 self.$field
             }
 
-            pub fn from_string($from_string_input: String) -> Result<Self, ::validators::ValidatedCustomizedVecError>{
+            pub fn from_string($from_string_input: String) -> std::result::Result<Self, ::validators::ValidatedCustomizedVecError>{
                 let $field = match $from_string {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -211,7 +211,7 @@ macro_rules! validated_customized_vec_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_str($from_str_input: &str) -> Result<Self, ::validators::ValidatedCustomizedVecError>{
+            pub fn from_str($from_str_input: &str) -> std::result::Result<Self, ::validators::ValidatedCustomizedVecError>{
                 let $field = match $from_str {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)
@@ -220,7 +220,7 @@ macro_rules! validated_customized_vec_struct {
                 Ok($name{$field})
             }
 
-            pub fn from_vec($from_vec_input: Vec<T>) -> Result<Self, ::validators::ValidatedCustomizedVecError>{
+            pub fn from_vec($from_vec_input: Vec<T>) -> std::result::Result<Self, ::validators::ValidatedCustomizedVecError>{
                 let $field = match $from_vec {
                     Ok(s)=> s,
                     Err(e)=> return Err(e)


### PR DESCRIPTION
... to avoid compilation error when crate calling macro has its own Result type.